### PR TITLE
Fix plugin compatibility with IDE build 261+

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -37,6 +37,7 @@ intellijPlatform {
     }
     ideaVersion {
       sinceBuild = sinceBuildMajorVersion
+      untilBuild = untilIdeVersion
     }
   }
   pluginVerification {


### PR DESCRIPTION
## Summary
- Add `untilBuild` to the `ideaVersion` plugin configuration block so it matches the `IIU.release.version` property
- Without this, the IntelliJ Platform Gradle Plugin defaults to a cap derived from `sinceBuild`, making the plugin incompatible with newer IDE versions (e.g. IU-261.22158.277)

## Test plan
- [x] Install the built plugin on IntelliJ IDEA 2026.1 (build 261.*) and verify it loads without compatibility errors
- [x] Verify the plugin still loads on older supported IDE versions (241+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)